### PR TITLE
add sde hooks in ci, prtest:sde

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -706,6 +706,10 @@ jobs:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patchcpuinfo
       if: matrix.qemu != ''
+
+    - name: Setup Intel SDE
+      uses: petarpetrovt/setup-sde@v3.0
+      if: matrix.sde
     - name: Install qemu
       run: |
         set -ex
@@ -741,6 +745,23 @@ jobs:
         ninja -C build install
         touch ${{ runner.tool_cache }}/qemu/built
       if: matrix.qemu != ''
+
+    - name: Configure Intel SDE
+      run: |
+        # Configure SDE as the test runner for x86_64 target when SDE is enabled
+        # The `-future` flag enables future instruction set emulation as an example
+        # You can modify this to test specific instruction sets like AVX, AVX2, etc.
+        echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=$SDE_PATH/sde64 -future --" >> $GITHUB_ENV
+        
+        # Similar optimizations as QEMU - build in release mode for faster testing
+        echo CARGO_PROFILE_DEV_OPT_LEVEL=2 >> $GITHUB_ENV
+        
+        # Enable environment variable to indicate SDE is being used
+        echo WASMTIME_TEST_SDE=1 >> $GITHUB_ENV
+        
+        # Similar to QEMU, reduce memory usage during SDE emulation
+        echo WASMTIME_TEST_NO_HOG_MEMORY=1 >> $GITHUB_ENV
+      if: matrix.sde
 
     - name: Configure ASAN
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -710,6 +710,7 @@ jobs:
     - name: Setup Intel SDE
       uses: petarpetrovt/setup-sde@v3.0
       if: matrix.sde
+
     - name: Install qemu
       run: |
         set -ex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -760,6 +760,9 @@ jobs:
         # Enable environment variable to indicate SDE is being used
         echo WASMTIME_TEST_SDE=1 >> $GITHUB_ENV
         
+        # Generic variable for skipping tests that are problematic under SDE (performance, compatibility, etc.)
+        echo WASMTIME_TEST_NO_SDE=1 >> $GITHUB_ENV
+        
         # Similar to QEMU, reduce memory usage during SDE emulation
         echo WASMTIME_TEST_NO_HOG_MEMORY=1 >> $GITHUB_ENV
       if: matrix.sde

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,6 +627,7 @@ dependencies = [
  "wasm-compose",
  "wasmparser 0.239.0",
  "wasmtime",
+ "wasmtime-test-util",
  "wasmtime-wasi",
 ]
 

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -54,6 +54,9 @@ const FAST_MATRIX = [
 //   QEMU and installing cross compilers to execute a cross-compiled test suite
 //   on CI.
 //
+// * `sde` - if `true`, indicates this test should use Intel SDE for instruction
+//   emulation. SDE will be set up and configured as the test runner.
+//
 // * `rust` - the Rust version to install, and if unset this'll be set to
 //   `default`
 const FULL_MATRIX = [
@@ -77,6 +80,13 @@ const FULL_MATRIX = [
     "filter": "asan",
     "rust": "wasmtime-ci-pinned-nightly",
     "target": "x86_64-unknown-linux-gnu",
+  },
+  {
+    "os": ubuntu,
+    "name": "Test Linux x86_64 with SDE",
+    "filter": "sde",
+    "isa": "x64",
+    "sde": true,
   },
   {
     "os": macos,

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -87,6 +87,7 @@ const FULL_MATRIX = [
     "filter": "sde",
     "isa": "x64",
     "sde": true,
+    "crates": "cranelift-tools",
   },
   {
     "os": macos,

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -238,7 +238,6 @@ async function shard(configs) {
   const sharded = [];
   for (const config of configs) {
     // If crates is specified, don't shard, just use the specified crates
-    if (config.crates) {
         if (config.crates) {
           sharded.push(Object.assign(
             {},

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -274,7 +274,11 @@ async function main() {
   // If the optional third argument to this script is `true` then that means all
   // tests are being run and no filtering should happen.
   if (process.argv[4] == 'true') {
-    console.log(JSON.stringify(await shard(FULL_MATRIX), undefined, 2));
+    // Even in full CI, exclude SDE tests unless explicitly requested
+    const fullMatrix = FULL_MATRIX.filter(config => 
+      !config.sde || commits.includes('prtest:sde')
+    );
+    console.log(JSON.stringify(await shard(fullMatrix), undefined, 2));
     return;
   }
 

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -87,7 +87,7 @@ const FULL_MATRIX = [
     "filter": "sde",
     "isa": "x64",
     "sde": true,
-    "crates": "cranelift-tools",
+    "crates": "cranelift-filetests",
   },
   {
     "os": macos,

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -237,6 +237,11 @@ async function shard(configs) {
   // created above.
   const sharded = [];
   for (const config of configs) {
+    // If crates is specified, don't shard, just use the specified crates
+    if (config.crates) {
+      sharded.push(config);
+      continue;
+    }
     for (const bucket of buckets) {
       sharded.push(Object.assign(
         {},

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -239,7 +239,16 @@ async function shard(configs) {
   for (const config of configs) {
     // If crates is specified, don't shard, just use the specified crates
     if (config.crates) {
-      sharded.push(config);
+        if (config.crates) {
+          sharded.push(Object.assign(
+            {},
+            config,
+            {
+              bucket: members
+                .map(c => c === config.crates ? `--package ${c}` : `--exclude ${c}`)
+                .join(" ")
+            }
+          ));
       continue;
     }
     for (const bucket of buckets) {

--- a/crates/misc/component-async-tests/Cargo.toml
+++ b/crates/misc/component-async-tests/Cargo.toml
@@ -36,3 +36,4 @@ wasm-compose = { workspace = true }
 test-programs-artifacts = { workspace = true }
 bytes = { workspace = true }
 once_cell = { version = "1.12.0" }
+wasmtime-test-util = { workspace = true }

--- a/crates/misc/component-async-tests/tests/scenario/post_return.rs
+++ b/crates/misc/component-async-tests/tests/scenario/post_return.rs
@@ -36,10 +36,7 @@ pub async fn async_post_return_caller() -> Result<()> {
 
 #[tokio::test]
 pub async fn async_sleep_post_return_caller() -> Result<()> {
-    if wasmtime_test_util::is_sde() {
-        println!(
-            "skipping `async_sleep_post_return_caller` test; async timing operations are unreliable under SDE"
-        );
+    if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
         return Ok(());
     }
     test_sleep_post_return(&[
@@ -51,10 +48,7 @@ pub async fn async_sleep_post_return_caller() -> Result<()> {
 
 #[tokio::test]
 pub async fn async_sleep_post_return_callee() -> Result<()> {
-    if wasmtime_test_util::is_sde() {
-        println!(
-            "skipping `async_sleep_post_return_callee` test; async timing operations are unreliable under SDE"
-        );
+    if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
         return Ok(());
     }
     test_sleep_post_return(&[test_programs_artifacts::ASYNC_SLEEP_POST_RETURN_CALLEE_COMPONENT])

--- a/crates/misc/component-async-tests/tests/scenario/post_return.rs
+++ b/crates/misc/component-async-tests/tests/scenario/post_return.rs
@@ -36,6 +36,10 @@ pub async fn async_post_return_caller() -> Result<()> {
 
 #[tokio::test]
 pub async fn async_sleep_post_return_caller() -> Result<()> {
+    if wasmtime_test_util::is_sde() {
+        println!("skipping `async_sleep_post_return_caller` test; async timing operations are unreliable under SDE");
+        return Ok(());
+    }
     test_sleep_post_return(&[
         test_programs_artifacts::ASYNC_SLEEP_POST_RETURN_CALLER_COMPONENT,
         test_programs_artifacts::ASYNC_SLEEP_POST_RETURN_CALLEE_COMPONENT,
@@ -45,6 +49,10 @@ pub async fn async_sleep_post_return_caller() -> Result<()> {
 
 #[tokio::test]
 pub async fn async_sleep_post_return_callee() -> Result<()> {
+    if wasmtime_test_util::is_sde() {
+        println!("skipping `async_sleep_post_return_callee` test; async timing operations are unreliable under SDE");
+        return Ok(());
+    }
     test_sleep_post_return(&[test_programs_artifacts::ASYNC_SLEEP_POST_RETURN_CALLEE_COMPONENT])
         .await
 }

--- a/crates/misc/component-async-tests/tests/scenario/post_return.rs
+++ b/crates/misc/component-async-tests/tests/scenario/post_return.rs
@@ -37,7 +37,9 @@ pub async fn async_post_return_caller() -> Result<()> {
 #[tokio::test]
 pub async fn async_sleep_post_return_caller() -> Result<()> {
     if wasmtime_test_util::is_sde() {
-        println!("skipping `async_sleep_post_return_caller` test; async timing operations are unreliable under SDE");
+        println!(
+            "skipping `async_sleep_post_return_caller` test; async timing operations are unreliable under SDE"
+        );
         return Ok(());
     }
     test_sleep_post_return(&[
@@ -50,7 +52,9 @@ pub async fn async_sleep_post_return_caller() -> Result<()> {
 #[tokio::test]
 pub async fn async_sleep_post_return_callee() -> Result<()> {
     if wasmtime_test_util::is_sde() {
-        println!("skipping `async_sleep_post_return_callee` test; async timing operations are unreliable under SDE");
+        println!(
+            "skipping `async_sleep_post_return_callee` test; async timing operations are unreliable under SDE"
+        );
         return Ok(());
     }
     test_sleep_post_return(&[test_programs_artifacts::ASYNC_SLEEP_POST_RETURN_CALLEE_COMPONENT])

--- a/crates/test-util/src/lib.rs
+++ b/crates/test-util/src/lib.rs
@@ -20,14 +20,6 @@ pub fn cargo_test_runner() -> Option<String> {
     Some(runner)
 }
 
-/// Returns true if tests are running under Intel SDE (Software Development Emulator)
-pub fn is_sde() -> bool {
-    std::env::var("WASMTIME_TEST_SDE").is_ok()
-        || cargo_test_runner().map_or(false, |runner| {
-            runner.contains("sde64") || runner.contains("sde32")
-        })
-}
-
 pub fn command(bin: impl AsRef<Path>) -> Command {
     let bin = bin.as_ref();
     match cargo_test_runner() {

--- a/crates/test-util/src/lib.rs
+++ b/crates/test-util/src/lib.rs
@@ -20,6 +20,13 @@ pub fn cargo_test_runner() -> Option<String> {
     Some(runner)
 }
 
+/// Returns true if tests are running under Intel SDE (Software Development Emulator)
+pub fn is_sde() -> bool {
+    std::env::var("WASMTIME_TEST_SDE").is_ok() ||
+        cargo_test_runner()
+            .map_or(false, |runner| runner.contains("sde64") || runner.contains("sde32"))
+}
+
 pub fn command(bin: impl AsRef<Path>) -> Command {
     let bin = bin.as_ref();
     match cargo_test_runner() {

--- a/crates/test-util/src/lib.rs
+++ b/crates/test-util/src/lib.rs
@@ -22,9 +22,10 @@ pub fn cargo_test_runner() -> Option<String> {
 
 /// Returns true if tests are running under Intel SDE (Software Development Emulator)
 pub fn is_sde() -> bool {
-    std::env::var("WASMTIME_TEST_SDE").is_ok() ||
-        cargo_test_runner()
-            .map_or(false, |runner| runner.contains("sde64") || runner.contains("sde32"))
+    std::env::var("WASMTIME_TEST_SDE").is_ok()
+        || cargo_test_runner().map_or(false, |runner| {
+            runner.contains("sde64") || runner.contains("sde32")
+        })
 }
 
 pub fn command(bin: impl AsRef<Path>) -> Command {

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -907,6 +907,10 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_pooling_allocator_striping() {
+        if wasmtime_test_util::is_sde() {
+            println!("skipping `test_pooling_allocator_striping` test; MPK instructions not supported under SDE");
+            return;
+        }
         if !mpk::is_supported() {
             println!("skipping `test_pooling_allocator_striping` test; mpk is not supported");
             return;

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -908,7 +908,9 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn test_pooling_allocator_striping() {
         if wasmtime_test_util::is_sde() {
-            println!("skipping `test_pooling_allocator_striping` test; MPK instructions not supported under SDE");
+            println!(
+                "skipping `test_pooling_allocator_striping` test; MPK instructions not supported under SDE"
+            );
             return;
         }
         if !mpk::is_supported() {

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -907,10 +907,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_pooling_allocator_striping() {
-        if wasmtime_test_util::is_sde() {
-            println!(
-                "skipping `test_pooling_allocator_striping` test; MPK instructions not supported under SDE"
-            );
+        if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
             return;
         }
         if !mpk::is_supported() {

--- a/crates/wasmtime/src/runtime/vm/mpk/enabled.rs
+++ b/crates/wasmtime/src/runtime/vm/mpk/enabled.rs
@@ -149,6 +149,10 @@ macro_rules! skip_if_mpk_unavailable {
             println!("> mpk is not supported: ignoring test");
             return;
         }
+        if wasmtime_test_util::is_sde() {
+            println!("> running under SDE which doesn't support MPK: ignoring test");
+            return;
+        }
     };
 }
 /// Necessary for inter-module access.
@@ -169,6 +173,10 @@ mod tests {
 
     #[test]
     fn check_initialized_keys() {
+        if wasmtime_test_util::is_sde() {
+            // MPK instructions (RDPKRU/WRPKRU) are not supported under SDE
+            return;
+        }
         if is_supported() {
             assert!(!keys(15).is_empty())
         }
@@ -176,6 +184,10 @@ mod tests {
 
     #[test]
     fn check_invalid_mark() {
+        if wasmtime_test_util::is_sde() {
+            // MPK instructions (RDPKRU/WRPKRU) are not supported under SDE
+            return;
+        }
         skip_if_mpk_unavailable!();
         let pkey = keys(15)[0];
         let unaligned_region = unsafe {
@@ -193,6 +205,10 @@ mod tests {
 
     #[test]
     fn check_masking() {
+        if wasmtime_test_util::is_sde() {
+            // MPK instructions (RDPKRU/WRPKRU) are not supported under SDE
+            return;
+        }
         skip_if_mpk_unavailable!();
         let original = pkru::read();
 

--- a/crates/wasmtime/src/runtime/vm/mpk/enabled.rs
+++ b/crates/wasmtime/src/runtime/vm/mpk/enabled.rs
@@ -149,8 +149,7 @@ macro_rules! skip_if_mpk_unavailable {
             println!("> mpk is not supported: ignoring test");
             return;
         }
-        if wasmtime_test_util::is_sde() {
-            println!("> running under SDE which doesn't support MPK: ignoring test");
+        if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
             return;
         }
     };
@@ -173,8 +172,7 @@ mod tests {
 
     #[test]
     fn check_initialized_keys() {
-        if wasmtime_test_util::is_sde() {
-            // MPK instructions (RDPKRU/WRPKRU) are not supported under SDE
+        if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
             return;
         }
         if is_supported() {
@@ -184,8 +182,7 @@ mod tests {
 
     #[test]
     fn check_invalid_mark() {
-        if wasmtime_test_util::is_sde() {
-            // MPK instructions (RDPKRU/WRPKRU) are not supported under SDE
+        if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
             return;
         }
         skip_if_mpk_unavailable!();
@@ -205,8 +202,7 @@ mod tests {
 
     #[test]
     fn check_masking() {
-        if wasmtime_test_util::is_sde() {
-            // MPK instructions (RDPKRU/WRPKRU) are not supported under SDE
+        if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
             return;
         }
         skip_if_mpk_unavailable!();

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2223,7 +2223,9 @@ start a print 1234
     #[test]
     fn cli_p1_much_stdout() -> Result<()> {
         if wasmtime_test_util::is_sde() {
-            println!("skipping `cli_p1_much_stdout` test; I/O intensive operations are very slow under SDE");
+            println!(
+                "skipping `cli_p1_much_stdout` test; I/O intensive operations are very slow under SDE"
+            );
             return Ok(());
         }
         run_much_stdout(CLI_P1_MUCH_STDOUT_COMPONENT, &[])
@@ -2232,7 +2234,9 @@ start a print 1234
     #[test]
     fn cli_p2_much_stdout() -> Result<()> {
         if wasmtime_test_util::is_sde() {
-            println!("skipping `cli_p2_much_stdout` test; I/O intensive operations are very slow under SDE");
+            println!(
+                "skipping `cli_p2_much_stdout` test; I/O intensive operations are very slow under SDE"
+            );
             return Ok(());
         }
         run_much_stdout(CLI_P2_MUCH_STDOUT_COMPONENT, &[])
@@ -2242,7 +2246,9 @@ start a print 1234
     #[cfg_attr(not(feature = "component-model-async"), ignore)]
     fn cli_p3_much_stdout() -> Result<()> {
         if wasmtime_test_util::is_sde() {
-            println!("skipping `cli_p3_much_stdout` test; I/O intensive operations are very slow under SDE");
+            println!(
+                "skipping `cli_p3_much_stdout` test; I/O intensive operations are very slow under SDE"
+            );
             return Ok(());
         }
         run_much_stdout(

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1789,8 +1789,7 @@ mod test_programs {
 
     #[test]
     fn cli_large_env() -> Result<()> {
-        if wasmtime_test_util::is_sde() {
-            println!("> running under SDE which has process execution limitations: skipping test");
+        if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
             return Ok(());
         }
         for wasm in [CLI_LARGE_ENV, CLI_LARGE_ENV_COMPONENT] {
@@ -2222,10 +2221,7 @@ start a print 1234
 
     #[test]
     fn cli_p1_much_stdout() -> Result<()> {
-        if wasmtime_test_util::is_sde() {
-            println!(
-                "skipping `cli_p1_much_stdout` test; I/O intensive operations are very slow under SDE"
-            );
+        if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
             return Ok(());
         }
         run_much_stdout(CLI_P1_MUCH_STDOUT_COMPONENT, &[])
@@ -2233,10 +2229,7 @@ start a print 1234
 
     #[test]
     fn cli_p2_much_stdout() -> Result<()> {
-        if wasmtime_test_util::is_sde() {
-            println!(
-                "skipping `cli_p2_much_stdout` test; I/O intensive operations are very slow under SDE"
-            );
+        if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
             return Ok(());
         }
         run_much_stdout(CLI_P2_MUCH_STDOUT_COMPONENT, &[])
@@ -2245,10 +2238,7 @@ start a print 1234
     #[test]
     #[cfg_attr(not(feature = "component-model-async"), ignore)]
     fn cli_p3_much_stdout() -> Result<()> {
-        if wasmtime_test_util::is_sde() {
-            println!(
-                "skipping `cli_p3_much_stdout` test; I/O intensive operations are very slow under SDE"
-            );
+        if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
             return Ok(());
         }
         run_much_stdout(
@@ -2296,8 +2286,7 @@ fn settings_command() -> Result<()> {
 #[cfg(target_arch = "x86_64")]
 #[test]
 fn profile_with_vtune() -> Result<()> {
-    if wasmtime_test_util::is_sde() {
-        println!("> running under SDE which doesn't support VTune profiling: skipping test");
+    if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
         return Ok(());
     }
     if !is_vtune_available() {

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1789,6 +1789,10 @@ mod test_programs {
 
     #[test]
     fn cli_large_env() -> Result<()> {
+        if wasmtime_test_util::is_sde() {
+            println!("> running under SDE which has process execution limitations: skipping test");
+            return Ok(());
+        }
         for wasm in [CLI_LARGE_ENV, CLI_LARGE_ENV_COMPONENT] {
             println!("run {wasm:?}");
             let mut cmd = get_wasmtime_command()?;
@@ -2274,6 +2278,10 @@ fn settings_command() -> Result<()> {
 #[cfg(target_arch = "x86_64")]
 #[test]
 fn profile_with_vtune() -> Result<()> {
+    if wasmtime_test_util::is_sde() {
+        println!("> running under SDE which doesn't support VTune profiling: skipping test");
+        return Ok(());
+    }
     if !is_vtune_available() {
         println!("> `vtune` is not available on the system path; skipping test");
         return Ok(());

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2222,17 +2222,29 @@ start a print 1234
 
     #[test]
     fn cli_p1_much_stdout() -> Result<()> {
+        if wasmtime_test_util::is_sde() {
+            println!("skipping `cli_p1_much_stdout` test; I/O intensive operations are very slow under SDE");
+            return Ok(());
+        }
         run_much_stdout(CLI_P1_MUCH_STDOUT_COMPONENT, &[])
     }
 
     #[test]
     fn cli_p2_much_stdout() -> Result<()> {
+        if wasmtime_test_util::is_sde() {
+            println!("skipping `cli_p2_much_stdout` test; I/O intensive operations are very slow under SDE");
+            return Ok(());
+        }
         run_much_stdout(CLI_P2_MUCH_STDOUT_COMPONENT, &[])
     }
 
     #[test]
     #[cfg_attr(not(feature = "component-model-async"), ignore)]
     fn cli_p3_much_stdout() -> Result<()> {
+        if wasmtime_test_util::is_sde() {
+            println!("skipping `cli_p3_much_stdout` test; I/O intensive operations are very slow under SDE");
+            return Ok(());
+        }
         run_much_stdout(
             CLI_P3_MUCH_STDOUT_COMPONENT,
             &["-Wcomponent-model-async", "-Sp3"],

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -1684,10 +1684,7 @@ fn instantiate_table_init_expr_oom() -> Result<()> {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn instantiate_global_init_oom() -> Result<()> {
-    if wasmtime_test_util::is_sde() {
-        println!(
-            "skipping `instantiate_global_init_oom` test; memory allocation stress testing is extremely slow under SDE"
-        );
+    if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
         return Ok(());
     }
     let mut config = Config::new();

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -1685,7 +1685,9 @@ fn instantiate_table_init_expr_oom() -> Result<()> {
 #[cfg_attr(miri, ignore)]
 fn instantiate_global_init_oom() -> Result<()> {
     if wasmtime_test_util::is_sde() {
-        println!("skipping `instantiate_global_init_oom` test; memory allocation stress testing is extremely slow under SDE");
+        println!(
+            "skipping `instantiate_global_init_oom` test; memory allocation stress testing is extremely slow under SDE"
+        );
         return Ok(());
     }
     let mut config = Config::new();

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -1684,6 +1684,10 @@ fn instantiate_table_init_expr_oom() -> Result<()> {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn instantiate_global_init_oom() -> Result<()> {
+    if wasmtime_test_util::is_sde() {
+        println!("skipping `instantiate_global_init_oom` test; memory allocation stress testing is extremely slow under SDE");
+        return Ok(());
+    }
     let mut config = Config::new();
     config.wasm_gc(true);
     config.wasm_function_references(true);

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -93,8 +93,7 @@ fn test_traps(store: &mut Store<()>, funcs: &[TestFunc], addr: u32, mem: &Memory
 #[wasmtime_test(wasm_features(simd))]
 #[cfg_attr(miri, ignore)]
 fn offsets_static_dynamic_oh_my(config: &mut Config) -> Result<()> {
-    if wasmtime_test_util::is_sde() {
-        println!("skipping `offsets_static_dynamic_oh_my` test; extremely slow under SDE");
+    if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
         return Ok(());
     }
     const GB: u64 = 1 << 30;

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -195,6 +195,9 @@ fn guards_present() -> Result<()> {
 #[cfg_attr(miri, ignore)]
 #[cfg_attr(asan, ignore)]
 fn guards_present_pooling(config: &mut Config) -> Result<()> {
+    if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
+        return Ok(());
+    }
     const GUARD_SIZE: u64 = 65536;
 
     let mut pool = crate::small_pool_config();
@@ -255,6 +258,9 @@ fn guards_present_pooling(config: &mut Config) -> Result<()> {
 #[cfg_attr(asan, ignore)]
 #[cfg(target_arch = "x86_64")] // only platform with mpk
 fn guards_present_pooling_mpk(config: &mut Config) -> Result<()> {
+    if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
+        return Ok(());
+    }
     if !wasmtime::PoolingAllocationConfig::are_memory_protection_keys_available() {
         println!("skipping `guards_present_pooling_mpk` test; mpk is not supported");
         return Ok(());

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -93,6 +93,10 @@ fn test_traps(store: &mut Store<()>, funcs: &[TestFunc], addr: u32, mem: &Memory
 #[wasmtime_test(wasm_features(simd))]
 #[cfg_attr(miri, ignore)]
 fn offsets_static_dynamic_oh_my(config: &mut Config) -> Result<()> {
+    if wasmtime_test_util::is_sde() {
+        println!("skipping `offsets_static_dynamic_oh_my` test; extremely slow under SDE");
+        return Ok(());
+    }
     const GB: u64 = 1 << 30;
     const MB: u64 = 1 << 20;
 

--- a/tests/disas.rs
+++ b/tests/disas.rs
@@ -68,10 +68,10 @@ fn main() -> Result<()> {
     if std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok() {
         return Ok(());
     }
-    
-    // SDE (Intel Software Development Emulator) can be useful for disassembly tests 
-    // as it allows validation of specific instruction sets, but these tests can be 
-    // slow under emulation. We continue with SDE but could add SDE-specific 
+
+    // SDE (Intel Software Development Emulator) can be useful for disassembly tests
+    // as it allows validation of specific instruction sets, but these tests can be
+    // slow under emulation. We continue with SDE but could add SDE-specific
     // filtering here if needed.
     if wasmtime_test_util::is_sde() {
         eprintln!("Running disassembly tests under Intel SDE - this may be slow");

--- a/tests/disas.rs
+++ b/tests/disas.rs
@@ -69,12 +69,11 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    // SDE (Intel Software Development Emulator) can be useful for disassembly tests
-    // as it allows validation of specific instruction sets, but these tests can be
-    // slow under emulation. We continue with SDE but could add SDE-specific
-    // filtering here if needed.
-    if wasmtime_test_util::is_sde() {
-        eprintln!("Running disassembly tests under Intel SDE - this may be slow");
+    // Similarly, SDE (Intel Software Development Emulator) emulation makes these
+    // tests very slow without much benefit since they only exercise architecture-
+    // independent compilation code. Disable this test suite when SDE is enabled.
+    if std::env::var("WASMTIME_TEST_NO_SDE").is_ok() {
+        return Ok(());
     }
 
     let _ = env_logger::try_init();

--- a/tests/disas.rs
+++ b/tests/disas.rs
@@ -68,6 +68,14 @@ fn main() -> Result<()> {
     if std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok() {
         return Ok(());
     }
+    
+    // SDE (Intel Software Development Emulator) can be useful for disassembly tests 
+    // as it allows validation of specific instruction sets, but these tests can be 
+    // slow under emulation. We continue with SDE but could add SDE-specific 
+    // filtering here if needed.
+    if wasmtime_test_util::is_sde() {
+        eprintln!("Running disassembly tests under Intel SDE - this may be slow");
+    }
 
     let _ = env_logger::try_init();
 


### PR DESCRIPTION

Adds SDE hooks.
Includes `prtest:sde` in commit message to attempt to test sde in ci